### PR TITLE
Modified filter generation to not write the "prefixes" term if the prefix list in DB is empty

### DIFF
--- a/bin/junos-filtergen.py
+++ b/bin/junos-filtergen.py
@@ -15,21 +15,22 @@ def generate_ipv4_filter(asn):
         f.write("policy-options {\n")
         f.write(f"policy-statement as{asn}-import-ipv4 {{\n")
         f.write("apply-flags omit;\n")
-        f.write("	term prefixes {\n")
-        f.write("		from {\n")
-        with open(f"{path}/db/{asn}.4.agg", "r") as prefixes:
-            for prefix in prefixes:
-                prefix = prefix.strip()
-                masklength = int(prefix.split("/")[1])
-                if prefix not in prefix_set:  # Check if the prefix is not in the set
-                    prefix_set.add(prefix)  # Add the prefix to the set
-                    if masklength == 24:
-                        f.write(f"			route-filter {prefix} exact;\n")
-                    elif masklength < 24:
-                        f.write(f"			route-filter {prefix} upto /24;\n")
-        f.write("		}\n")
-        f.write("		then next policy;\n")
-        f.write("	}\n")
+        if(os.path.getsize(f"{path}/db/{asn}.4.agg") > 0):
+            f.write("	term prefixes {\n")
+            f.write("		from {\n")
+            with open(f"{path}/db/{asn}.4.agg", "r") as prefixes:
+                for prefix in prefixes:
+                    prefix = prefix.strip()
+                    masklength = int(prefix.split("/")[1])
+                    if prefix not in prefix_set:  # Check if the prefix is not in the set
+                        prefix_set.add(prefix)  # Add the prefix to the set
+                        if masklength == 24:
+                            f.write(f"			route-filter {prefix} exact;\n")
+                        elif masklength < 24:
+                            f.write(f"			route-filter {prefix} upto /24;\n")
+            f.write("		}\n")
+            f.write("		then next policy;\n")
+            f.write("	}\n")
         f.write("	term reject {\n")
         f.write("		then reject;\n")
         f.write("	}\n")
@@ -42,21 +43,22 @@ def generate_ipv6_filter(asn):
         f.write("policy-options {\n")
         f.write(f"policy-statement as{asn}-import-ipv6 {{\n")
         f.write("apply-flags omit;\n")
-        f.write("  term prefixes {\n")
-        f.write("		from {\n")
-        with open(f"{path}/db/{asn}.6.agg", "r") as prefixes6:
-            for prefix6 in prefixes6:
-                prefix6 = prefix6.strip()
-                masklength6 = int(prefix6.split("/")[1])
-                if prefix6 not in prefix_set:  # Check if the prefix is not in the set
-                    prefix_set.add(prefix6)  # Add the prefix to the set
-                    if masklength6 == 48:
-                        f.write(f"			route-filter {prefix6} exact;\n")
-                    elif masklength6 < 48:
-                        f.write(f"			route-filter {prefix6} upto /48;\n")
-        f.write("		}\n")
-        f.write("		then next policy;\n")
-        f.write("  }\n")
+        if(os.path.getsize(f"{path}/db/{asn}.6.agg") > 0):
+            f.write("  term prefixes {\n")
+            f.write("		from {\n")
+            with open(f"{path}/db/{asn}.6.agg", "r") as prefixes6:
+                for prefix6 in prefixes6:
+                    prefix6 = prefix6.strip()
+                    masklength6 = int(prefix6.split("/")[1])
+                    if prefix6 not in prefix_set:  # Check if the prefix is not in the set
+                        prefix_set.add(prefix6)  # Add the prefix to the set
+                        if masklength6 == 48:
+                            f.write(f"			route-filter {prefix6} exact;\n")
+                        elif masklength6 < 48:
+                            f.write(f"			route-filter {prefix6} upto /48;\n")
+            f.write("		}\n")
+            f.write("		then next policy;\n")
+            f.write("  }\n")
         f.write("  term reject {\n")
         f.write("          then reject;\n")
         f.write("  }\n")


### PR DESCRIPTION
Problem: If the list of prefixes generated for an ASN/AS-Set is empty, junos-filtergen.py would write invalid config as such:
```
term prefixes {
    from {
    }
    then next policy;
}
```

I have modified the script to simply not generate that term if the file containing the generated prefixes is empty.